### PR TITLE
UTF-8 encoding and quotes around names

### DIFF
--- a/emails.py
+++ b/emails.py
@@ -9,4 +9,4 @@ users = response.body['members']
 
 for user in users:
     if "email" in user["profile"]:
-        print user["profile"]["real_name"]+","+user["profile"]["email"]
+        print '"'+user["profile"]["real_name"].encode('utf-8').strip()+'",'+user["profile"]["email"].encode('utf-8').strip()


### PR DESCRIPTION
I ran into a few errors with names containing special characters. This UTF-8 encodes both strings before outputting.

As an added bonus, added quotes around the full name (some of mine were last/first with a comma).